### PR TITLE
Allow absolute urls

### DIFF
--- a/byterestclient/__init__.py
+++ b/byterestclient/__init__.py
@@ -38,6 +38,8 @@ class ByteRESTClient(object):
             return response.json
 
     def get_absolute_url(self, path):
+        if path.startswith(self.endpoint):
+            return path
         return self.endpoint.rstrip('/') + '/' + path.lstrip('/')
 
     def get(self, path, *args, **kwargs):

--- a/tests/unit/test_apiclient.py
+++ b/tests/unit/test_apiclient.py
@@ -179,3 +179,8 @@ class TestByteRESTClient(TestCase):
         client = ByteRESTClient(endpoint="http://henk.nl/api/")
         absolute_url = client.get_absolute_url("")
         self.assertEqual(absolute_url, "http://henk.nl/api/")
+
+    def test_that_get_absolute_url_does_not_alter_absolute_urls(self):
+        client = ByteRESTClient(endpoint="http://henk.nl/api/")
+        absolute_url = client.get_absolute_url("http://henk.nl/api/foo/bar")
+        self.assertEqual(absolute_url, "http://henk.nl/api/foo/bar")


### PR DESCRIPTION
It only checks for internal URLs, calls to external URLs will implicitly fail.
