### PR TITLE
Don't use exception.message, it's been deprecated - just cast to string

### DIFF
--- a/byterestclient/__init__.py
+++ b/byterestclient/__init__.py
@@ -15,7 +15,7 @@ class ByteRESTClient(object):
             self.key = token or os.environ['REST_CLIENT_TOKEN']
             self.endpoint = endpoint or os.environ['REST_CLIENT_ENDPOINT']
         except KeyError as e:
-            raise RuntimeError('Environment variable %s is not properly configured for ByteRESTClient' % e.message)
+            raise RuntimeError('Environment variable %s is not properly configured for ByteRESTClient' % e)
 
         self.headers = {
             'Authorization': 'Token %s' % self.key,


### PR DESCRIPTION
```
/home/rik/.virtualenvs/sp-python/src/python-byterestclient/byterestclient/__init__.py:18: DeprecationWarning: BaseException.message has been deprecated as of Python 2.6
  raise RuntimeError('Environment variable %s is not properly configured for ByteRESTClient' % e.message)
```