### PR TITLE
Do not parse json without content

### DIFF
--- a/byterestclient/__init__.py
+++ b/byterestclient/__init__.py
@@ -58,6 +58,9 @@ class ByteRESTClient(object):
         if response.status_code == 204:
             return None
 
+        if not response.content:
+            return response
+
         # support 0.12.1 that has json as property, newer requests has json as method
         if callable(response.json):
             return response.json()

--- a/tests/unit/test_apiclient.py
+++ b/tests/unit/test_apiclient.py
@@ -244,3 +244,19 @@ class TestByteRESTClient(TestCase):
         client = ByteRESTClient(endpoint="http://henk:pass@aap.nl:8080/mies/")
         absolute_url = client.format_absolute_url("/henk;zus?aap=noot#noot")
         self.assertEqual(absolute_url, "http://henk:pass@aap.nl:8080/mies/henk;zus?aap=noot#noot")
+
+    def test_handles_200_response_with_empty_body(self):
+        self.mock_response._content = ''
+        client = ByteRESTClient()
+
+        response = client.get('http://henk.nl')
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_handles_200_response_without_body(self):
+        self.mock_response._content = None
+        client = ByteRESTClient()
+
+        response = client.get('http://henk.nl')
+
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
The client raises when parsing the response to a successful (delete) request, when there is no body in said response: e.g., [HNAPI logs](https://kibana.byte.nl/app/apm#/hypernode-api/errors/d588299feb4f3f14c2adef1284d226d4?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now%2Fw,mode:quick,to:now%2Fw))).