### PR TITLE
Adding optional kwarg for returning Response object directly

### DIFF
--- a/byterestclient/__init__.py
+++ b/byterestclient/__init__.py
@@ -47,6 +47,9 @@ class ByteRESTClient(object):
             **kwargs
         )
 
+        if kwargs.pop('return_response_object', False):
+            return response
+
         response.raise_for_status()
 
         if 300 <= response.status_code < 400:

--- a/tests/unit/test_apiclient.py
+++ b/tests/unit/test_apiclient.py
@@ -110,6 +110,34 @@ class TestByteRESTClient(TestCase):
             allow_redirects=False
         )
 
+    def test_restclient_request_returns_response_object_if_return_response_object_kwarg_is_true(self):
+        client = ByteRESTClient()
+        ret = client.request('get', '/varnish/v2/config/henkslaaf.nl', return_response_object=True)
+        self.assertEqual(ret, self.mock_get.return_value)
+
+    def test_restclient_request_does_not_call_raise_for_status_if_return_response_object_kwarg_is_true(self):
+        client = ByteRESTClient()
+        client.request('get', '/varnish/v2/config/henkslaaf.nl', return_response_object=True)
+        self.mock_get.raise_for_status.assert_not_called()
+
+    def test_restclient_request_does_not_call_raise_for_status_if_return_response_object_kwarg_is_false(self):
+        mock_response = mock.Mock(status_code=200)
+        self.mock_get.return_value = mock_response
+
+        client = ByteRESTClient()
+        client.request('get', '/varnish/v2/config/henkslaaf.nl', return_response_object=False)
+
+        mock_response.raise_for_status.assert_called_once()
+
+    def test_restclient_request_does_not_call_raise_for_status_if_return_response_object_kwarg_is_absent(self):
+        mock_response = mock.Mock(status_code=200)
+        self.mock_get.return_value = mock_response
+
+        client = ByteRESTClient()
+        client.request('get', '/varnish/v2/config/henkslaaf.nl')
+
+        mock_response.raise_for_status.assert_called_once()
+
     def test_restclient_request_returns_decoded_json_response(self):
         client = ByteRESTClient()
         ret = client.request('get', '/get/', data={"a": "b"})


### PR DESCRIPTION
Related to [HNWEB-3322](https://jira.byte.nl/browse/HNWEB-3322)

Related PR https://github.com/ByteInternet/hypernode-api/pull/2181

With the `return_response_object` kwarg the response object can be returned right away before any other actions are performed on it (or partially returned). This is useful for example if this client is used as a proxy client and the full HTTP response (so including code) should be returned.

Current implementations of this client will remain unaffected by this change.