### PR TITLE
Pop `return_response_object` from kwags before passing to request

### DIFF
--- a/byterestclient/__init__.py
+++ b/byterestclient/__init__.py
@@ -35,6 +35,7 @@ class ByteRESTClient(object):
             self.headers.update(headers)
 
     def request(self, method, path, data=None, *args, **kwargs):
+        return_response_object = kwargs.pop('return_response_object', False)
         url = self.format_absolute_url(path)
         request_method = getattr(requests, method)
 
@@ -47,7 +48,7 @@ class ByteRESTClient(object):
             **kwargs
         )
 
-        if kwargs.pop('return_response_object', False):
+        if return_response_object:
             return response
 
         response.raise_for_status()

--- a/tests/unit/test_apiclient.py
+++ b/tests/unit/test_apiclient.py
@@ -115,6 +115,13 @@ class TestByteRESTClient(TestCase):
         ret = client.request('get', '/varnish/v2/config/henkslaaf.nl', return_response_object=True)
         self.assertEqual(ret, self.mock_get.return_value)
 
+    def test_restclient_request_does_not_call_request_with_response_object_kwarg(self):
+        client = ByteRESTClient()
+        client.request('get', '/varnish/v2/config/henkslaaf.nl', return_response_object=True)
+
+        args, kwargs = self.mock_get.call_args
+        self.assertNotIn('return_response_object', kwargs.keys())
+
     def test_restclient_request_does_not_call_raise_for_status_if_return_response_object_kwarg_is_true(self):
         client = ByteRESTClient()
         client.request('get', '/varnish/v2/config/henkslaaf.nl', return_response_object=True)


### PR DESCRIPTION
Related to [HNWEB-3322](https://jira.byte.nl/browse/HNWEB-3322)

Request will raise an error because it doesn't expect the kwarg.