### PR TITLE
Add function to process data so it's easy to overwrite.

### DIFF
--- a/byterestclient/__init__.py
+++ b/byterestclient/__init__.py
@@ -34,14 +34,18 @@ class ByteRESTClient(object):
         if headers:
             self.headers.update(headers)
 
+    def preprocess_data(self, data):
+        return json.dumps(data or {})
+
     def request(self, method, path, data=None, *args, **kwargs):
         return_response_object = kwargs.pop('return_response_object', False)
         url = self.format_absolute_url(path)
         request_method = getattr(requests, method)
 
+        request_data = self.preprocess_data(data)
         response = request_method(
             url,
-            data=json.dumps(data or {}),
+            data=request_data,
             headers=self.headers,
             allow_redirects=False,
             *args,

--- a/tests/unit/test_apiclient.py
+++ b/tests/unit/test_apiclient.py
@@ -295,3 +295,28 @@ class TestByteRESTClient(TestCase):
         response = client.get('http://henk.nl')
 
         self.assertEqual(response.status_code, 200)
+
+    def test_restclient_request_makes_correct_call_using_preprocess_data(self):
+        self.preprocess_data = self._set_up_patch('byterestclient.ByteRESTClient.preprocess_data')
+
+        client = ByteRESTClient()
+        client.request('get', '/', data={"a": "b"})
+        self.mock_get.assert_called_once_with(
+            REST_CLIENT_ENDPOINT + "/",
+            data=self.preprocess_data.return_value,
+            headers=client.headers,
+            allow_redirects=False
+        )
+
+    def test_calls_preprocess_data_correctly(self):
+        self.preprocess_data = self._set_up_patch('byterestclient.ByteRESTClient.preprocess_data')
+
+        client = ByteRESTClient()
+        client.request('get', '/', data={"a": "b"})
+        self.preprocess_data.assert_called_once_with({'a': 'b'})
+
+    def test_preprocess_data_returns_json_dumped_data(self):
+        client = ByteRESTClient()
+        data = client.preprocess_data({"a": "b"})
+
+        self.assertEqual(data, json.dumps({"a": "b"}))


### PR DESCRIPTION
Sometimes you don't want to send json, then json dumping is in the way and taking over the `request` function is too much